### PR TITLE
Make debug much faster

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,28 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-Clink-arg=-fuse-ld=lld"]
+
+# NOTE: you must manually install https://github.com/michaeleisel/zld on mac. you can easily do this with the "brew" package manager:
+# `brew install michaeleisel/zld/zld`
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/zld"]
+
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/zld"]
+
+[target.x86_64-pc-windows-msvc]
+linker = "rust-lld.exe"
+
+[target.wasm32-unknown-unknown]
+runner = "wasm-server-runner"
+
+[target.'cfg(all())']
+rustflags = [
+    "-Wclippy::pedantic",
+    "-Wclippy::unwrap_used",
+    "-Wclippy::expect_used",
+    "-Wclippy::doc_markdown",
+    "-Wclippy::doc_link_with_quotes",
+    "-Wclippy::missing_panics_doc",
+    "-Wmissing_docs",
+]

--- a/assemble/src/lib.rs
+++ b/assemble/src/lib.rs
@@ -214,14 +214,11 @@ fn pass1(ty: Type, lines: Lines<BufReader<File>>) -> Result<ASTOutput> {
                 }
                 // An ORG statement must be followed by a u16 value.
                 State::Org => {
-                    let pc = match parse_val(token, true) {
-                        Some(TokenVal::Val16(v)) => v,
-                        _ => {
+                    let Some(TokenVal::Val16(pc)) = parse_val(token, true) else {
                             return Err(eyre!(
                                 "Error parsing line {}: invalid ORG value not 16 bit - {token} - {line}",
                                 line_num + 1,
                             ));
-                        }
                     };
                     l.push(Token::Org(pc));
                     State::Remainder

--- a/assemble/src/lib.rs
+++ b/assemble/src/lib.rs
@@ -338,7 +338,7 @@ fn pass1(ty: Type, lines: Lines<BufReader<File>>) -> Result<ASTOutput> {
                             // Either Absolute, ZeroPage, Relative or a Label
                             _ => token.as_bytes(),
                         };
-                        // Safety: We know the remainder is valid utf8 since we only removed ASCII
+                        // SAFETY: We know the remainder is valid utf8 since we only removed ASCII
                         //         and started with a valid utf8 str.
                         let op_val = unsafe { std::str::from_utf8(val).unwrap_unchecked() };
 
@@ -654,7 +654,7 @@ fn generate_output(ty: Type, ast_output: &mut ASTOutput) -> Result<Assembly> {
                 }
                 Token::Equ(td) => {
                     let val: TokenVal;
-                    // Safety: EQU is defined always per above parsing.
+                    // SAFETY: EQU is defined always per above parsing.
                     unsafe { val = get_label(&ast_output.labels, td).val.unwrap_unchecked() }
                     match val {
                         TokenVal::Val8(v) => {
@@ -750,7 +750,7 @@ fn generate_output(ty: Type, ast_output: &mut ASTOutput) -> Result<Assembly> {
                                 if s == "*" {
                                     TokenVal::Val16(o.pc)
                                 } else {
-                                    // Safety: We just checked labels above has everything referenced and filled in.
+                                    // SAFETY: We just checked labels above has everything referenced and filled in.
                                     // The one exception is * which we just handled.
                                     unsafe {
                                         get_label(&ast_output.labels, s).val.unwrap_unchecked()
@@ -881,12 +881,12 @@ pub fn parse(ty: Type, lines: Lines<BufReader<File>>) -> Result<Assembly> {
 // Given a labels map (label->LabelDef) return the labeldef directly w/o checking.
 // This should be only called after AST building as it assumes all labels are valid.
 fn get_label<'a>(hm: &'a HashMap<String, LabelDef>, label: &String) -> &'a LabelDef {
-    // Safety: Only called after AST built so all labels are in map.
+    // SAFETY: Only called after AST built so all labels are in map.
     unsafe { hm.get(label).unwrap_unchecked() }
 }
 
 fn get_label_mut<'a>(hm: &'a mut HashMap<String, LabelDef>, label: &String) -> &'a mut LabelDef {
-    // Safety: Only called after AST built so all labels are in map.
+    // SAFETY: Only called after AST built so all labels are in map.
     unsafe { hm.get_mut(label).unwrap_unchecked() }
 }
 

--- a/assembler/src/main.rs
+++ b/assembler/src/main.rs
@@ -49,5 +49,5 @@ where
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
-    Args::command().debug_assert()
+    Args::command().debug_assert();
 }

--- a/c64basic/src/lib.rs
+++ b/c64basic/src/lib.rs
@@ -8,6 +8,7 @@ use std::num::Wrapping;
 use std::str;
 use strum_macros::{Display, EnumIter, EnumString};
 
+#[cfg(test)]
 mod tests;
 
 /// `BASIC_LOAD_ADDR` is the memory location where c64 basic programs

--- a/c64basic/src/lib.rs
+++ b/c64basic/src/lib.rs
@@ -788,10 +788,10 @@ pub fn list(pc: Wrapping<u16>, r: &impl Memory) -> Result<(String, Wrapping<u16>
             0x00 => break,
             0x01..=ASCII_END => {
                 b[0] = tok;
-                // Safety: We know this is < 128 so it must be valid utf8.
+                // SAFETY: We know this is < 128 so it must be valid utf8.
                 unsafe { str::from_utf8(&b).unwrap_unchecked() }
             }
-            // Safety: We know the range of map keys.
+            // SAFETY: We know the range of map keys.
             KEYWORD_START..=KEYWORD_HIGH => unsafe {
                 tmp = KEYWORDS.get(&tok).unwrap_unchecked().to_string();
                 tmp.as_str()

--- a/c64basic/src/tests.rs
+++ b/c64basic/src/tests.rs
@@ -1,14 +1,11 @@
-#[cfg(test)]
-mod tests {
-    use super::super::{list, BASIC_LOAD_ADDR};
-    use rusty6502::prelude::*;
-    use std::error::Error;
-    use std::fmt::Write as _;
-    use std::fs::read;
-    use std::num::Wrapping;
-    use std::path::Path;
+use super::{list, BASIC_LOAD_ADDR};
+use rusty6502::prelude::*;
+use std::fmt::Write as _;
+use std::fs::read;
+use std::num::Wrapping;
+use std::path::Path;
 
-    macro_rules! list_test {
+macro_rules! list_test {
         ($suite:ident, $($name:ident: $file:literal,)*) => {
             mod $suite {
                 use std::error::Error;
@@ -21,7 +18,7 @@ mod tests {
                         // This should halt the cpu if a test goes off the rails.
                         let mut r = FlatRAM::new().vectors(Vectors {
                             nmi: 0x0202,
-                            reset: 0x1FFe,
+                            reset: 0x1FFE,
                             irq: 0xD001,
                         });
                         r.power_on();
@@ -58,58 +55,56 @@ mod tests {
         }
     }
 
-    // These tests are images we use in cpu testing but they are c64 PRG files so
-    // also work for basic sanity checking here.
-    list_test!(
-        list_tests,
-        dadc: "dadc.prg",
-        dincsbc:"dincsbc.prg",
-        dincsbc_deccmp: "dincsbc-deccmp.prg",
-        droradc: "droradc.prg",
-        dsbc: "dsbc.prg",
-        dsbc_cmp_flags: "dsbc-cmp-flags.prg",
-        sbx: "sbx.prg",
-        vsbx: "vsbx.prg",
-    );
+// These tests are images we use in cpu testing but they are c64 PRG files so
+// also work for basic sanity checking here.
+list_test!(
+    list_tests,
+    dadc: "dadc.prg",
+    dincsbc:"dincsbc.prg",
+    dincsbc_deccmp: "dincsbc-deccmp.prg",
+    droradc: "droradc.prg",
+    dsbc: "dsbc.prg",
+    dsbc_cmp_flags: "dsbc-cmp-flags.prg",
+    sbx: "sbx.prg",
+    vsbx: "vsbx.prg",
+);
 
-    #[test]
-    fn bad_token() -> Result<(), Box<dyn Error>> {
-        // This should halt the cpu if a test goes off the rails.
-        let mut r = FlatRAM::new().vectors(Vectors {
-            nmi: 0x0202,
-            reset: 0x1FFe,
-            irq: 0xD001,
-        });
-        r.power_on();
+#[test]
+fn bad_token() {
+    // This should halt the cpu if a test goes off the rails.
+    let mut r = FlatRAM::new().vectors(Vectors {
+        nmi: 0x0202,
+        reset: 0x1FFE,
+        irq: 0xD001,
+    });
+    r.power_on();
 
-        // Create a single line which is
-        // 10 ILLEGAL_OPCODE
+    // Create a single line which is
+    // 10 ILLEGAL_OPCODE
 
-        // NOTE: All address/line numbers are in little endian.
+    // NOTE: All address/line numbers are in little endian.
 
-        // Next PC
-        r.write(BASIC_LOAD_ADDR, 0x07);
-        r.write(BASIC_LOAD_ADDR + 1, 0x08);
+    // Next PC
+    r.write(BASIC_LOAD_ADDR, 0x07);
+    r.write(BASIC_LOAD_ADDR + 1, 0x08);
 
-        // Line number
-        r.write(BASIC_LOAD_ADDR + 2, 0x0A);
-        r.write(BASIC_LOAD_ADDR + 3, 0x00);
+    // Line number
+    r.write(BASIC_LOAD_ADDR + 2, 0x0A);
+    r.write(BASIC_LOAD_ADDR + 3, 0x00);
 
-        // Operation
-        r.write(BASIC_LOAD_ADDR + 4, 0xCC);
+    // Operation
+    r.write(BASIC_LOAD_ADDR + 4, 0xCC);
 
-        // NUL for end of line
-        r.write(BASIC_LOAD_ADDR + 5, 0x00);
+    // NUL for end of line
+    r.write(BASIC_LOAD_ADDR + 5, 0x00);
 
-        // Next PC which is 0x0000 indicating done.
-        r.write(BASIC_LOAD_ADDR + 6, 0x00);
-        r.write(BASIC_LOAD_ADDR + 7, 0x00);
+    // Next PC which is 0x0000 indicating done.
+    r.write(BASIC_LOAD_ADDR + 6, 0x00);
+    r.write(BASIC_LOAD_ADDR + 7, 0x00);
 
-        let res = list(Wrapping(BASIC_LOAD_ADDR), &r);
-        assert!(res.is_err());
-        if let Err(e) = res {
-            println!("{e}");
-        }
-        Ok(())
+    let res = list(Wrapping(BASIC_LOAD_ADDR), &r);
+    assert!(res.is_err());
+    if let Err(e) = res {
+        println!("{e}");
     }
 }

--- a/convertprg/src/main.rs
+++ b/convertprg/src/main.rs
@@ -191,5 +191,5 @@ fn write_c64_values(block: &mut [u8]) {
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
-    Args::command().debug_assert()
+    Args::command().debug_assert();
 }

--- a/cpu/Cargo.toml
+++ b/cpu/Cargo.toml
@@ -15,4 +15,3 @@ rand = { workspace = true }
 strum_macros = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
-ringbuffer = { version = "0.10.0" }

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -18,6 +18,7 @@ pub use crate::lookup::*;
 
 pub mod disassemble;
 
+#[cfg(test)]
 mod tests;
 
 /// `AddressMode` defines the 6502 addressing modes.
@@ -885,6 +886,7 @@ pub enum CPUError {
     },
 }
 
+#[derive(Copy, Clone)]
 enum Register {
     A,
     X,
@@ -3855,8 +3857,8 @@ impl Memory for FlatRAM {
         self.memory[(IRQ_VECTOR + 1) as usize] = ((self.vectors.irq & 0xff00) >> 8) as u8;
     }
 
-    /// `ram` gives a copy of FlatRAM back out as an array.
-    fn ram<'a>(&'a self) -> &'a [u8; MAX_SIZE] {
+    /// `ram` gives a copy of `FlatRAM` back out as an array.
+    fn ram(&self) -> &[u8; MAX_SIZE] {
         &self.memory
     }
 }

--- a/cpu/src/lookup.rs
+++ b/cpu/src/lookup.rs
@@ -582,7 +582,7 @@ pub fn resolve_opcode(t: Type, op: &Opcode, mode: &AddressMode) -> Result<&'stat
     let hm: &HashMap<AddressMode, Vec<u8>>;
     match t {
         Type::NMOS | Type::NMOS6510 | Type::Ricoh => {
-            // Safety: When we built OPCODES we validated all Opcode were present
+            // SAFETY: When we built OPCODES we validated all Opcode were present
             unsafe {
                 hm = NMOS_OPCODES.get(op).unwrap_unchecked();
             }
@@ -601,7 +601,7 @@ pub fn resolve_opcode(t: Type, op: &Opcode, mode: &AddressMode) -> Result<&'stat
 pub fn opcode_op(t: Type, op: u8) -> Operation {
     match t {
         Type::NMOS | Type::NMOS6510 | Type::Ricoh =>
-        // Safety: We know a u8 is in range due to how we build this
+        // SAFETY: We know a u8 is in range due to how we build this
         //         so a direct index is fine.
         {
             NMOS_OPCODES_VALUES[usize::from(op)]

--- a/cpu/src/lookup.rs
+++ b/cpu/src/lookup.rs
@@ -578,6 +578,9 @@ lazy_static! {
 ///
 /// # Errors
 /// If the `AddressMode` is not valid for this opcode an error will result.
+///
+/// # Panics
+/// CMOS unimplemented at present.
 pub fn resolve_opcode(t: Type, op: &Opcode, mode: &AddressMode) -> Result<&'static Vec<u8>> {
     let hm: &HashMap<AddressMode, Vec<u8>>;
     match t {
@@ -597,6 +600,9 @@ pub fn resolve_opcode(t: Type, op: &Opcode, mode: &AddressMode) -> Result<&'stat
 
 /// Given an opcode u8 value this will return the Operation struct
 /// defining it. i.e. `Opcode` and `AddressMode`.
+///
+/// # Panics
+/// CMOS unimplemented at present.
 #[must_use]
 pub fn opcode_op(t: Type, op: u8) -> Operation {
     match t {

--- a/cpu/src/tests.rs
+++ b/cpu/src/tests.rs
@@ -1,172 +1,169 @@
-#[cfg(test)]
-mod tests {
-    use crate::{
-        CPUError, CPUState, ChipDef, Cpu, Flags, FlatRAM, InterruptState, InterruptStyle, OpState,
-        Tick, Type, Vectors, P_B, P_DECIMAL, P_INTERRUPT, P_NEGATIVE, P_S1, P_ZERO, STACK_START,
-    };
-    use chip::Chip;
-    use color_eyre::eyre::{eyre, Result};
-    use irq::Sender;
-    use memory::Memory;
-    use std::cell::RefCell;
-    use std::collections::HashSet;
-    use std::fmt::{Display, Write};
-    use std::fs::read;
-    use std::num::Wrapping;
-    use std::path::Path;
-    use std::rc::Rc;
+use crate::{
+    CPUError, CPUState, ChipDef, Cpu, Flags, FlatRAM, InterruptState, InterruptStyle, OpState,
+    Tick, Type, Vectors, P_B, P_DECIMAL, P_INTERRUPT, P_NEGATIVE, P_S1, P_ZERO, STACK_START,
+};
+use chip::Chip;
+use color_eyre::eyre::{eyre, Result};
+use irq::Sender;
+use memory::Memory;
+use std::cell::RefCell;
+use std::collections::HashSet;
+use std::fmt::{Display, Write};
+use std::fs::read;
+use std::num::Wrapping;
+use std::path::Path;
+use std::rc::Rc;
 
-    // Debug provides a way to capture debug output from a Cpu
-    // without having to grab everything. Normally a few recent
-    // instructions is all one needs. The functional test below for
-    // instance runs millions of instructions which can lead to very
-    // large buffering during a test run.
-    struct Debug<T> {
-        state: Vec<Rc<RefCell<T>>>,
-        cur: RefCell<usize>,
-        wrapped: RefCell<bool>,
+// Debug provides a way to capture debug output from a Cpu
+// without having to grab everything. Normally a few recent
+// instructions is all one needs. The functional test below for
+// instance runs millions of instructions which can lead to very
+// large buffering during a test run.
+struct Debug<T> {
+    state: Vec<Rc<RefCell<T>>>,
+    cur: RefCell<usize>,
+    wrapped: RefCell<bool>,
+}
+
+impl<T: Display + std::default::Default> Debug<T> {
+    fn new(cap: usize) -> Self {
+        let mut d = Self {
+            state: Vec::with_capacity(cap),
+            cur: RefCell::new(0),
+            wrapped: RefCell::new(false),
+        };
+        for _ in 0..cap {
+            d.state.push(Rc::new(RefCell::new(T::default())));
+        }
+        d
     }
 
-    impl<T: Display + std::default::Default> Debug<T> {
-        fn new(cap: usize) -> Self {
-            let mut d = Self {
-                state: Vec::with_capacity(cap),
-                cur: RefCell::new(0),
-                wrapped: RefCell::new(false),
-            };
-            for _ in 0..cap {
-                d.state.push(Rc::new(RefCell::new(T::default())));
-            }
-            d
-        }
-
-        fn dump(&self, s: String) -> String {
-            let mut out = String::new();
-            writeln!(out, "\nFAIL: {s}\n\nExecution buffer:\n").unwrap();
-            if *self.wrapped.borrow() {
-                for i in *self.cur.borrow()..self.state.len() {
-                    writeln!(out, "{}", self.state[i].borrow()).unwrap();
-                }
-            }
-            for i in 0..*self.cur.borrow() {
+    fn dump(&self, s: &str) -> String {
+        let mut out = String::new();
+        writeln!(out, "\nFAIL: {s}\n\nExecution buffer:\n").unwrap();
+        if *self.wrapped.borrow() {
+            for i in *self.cur.borrow()..self.state.len() {
                 writeln!(out, "{}", self.state[i].borrow()).unwrap();
             }
-            out
         }
-
-        fn roll_buffer(&self) {
-            // Now roll the circular buffer portion of this.
-            let mut new = *self.cur.borrow() + 1;
-            if new >= self.state.len() {
-                *self.wrapped.borrow_mut() = true;
-                new = 0;
-            }
-            *self.cur.borrow_mut() = new;
+        for i in 0..*self.cur.borrow() {
+            writeln!(out, "{}", self.state[i].borrow()).unwrap();
         }
+        out
     }
 
-    impl Debug<String> {
-        fn debug(&self, s: String) {
-            let r = &*self.state[*self.cur.borrow()];
-            let _ = &*r.replace(s);
-            // Now roll the circular buffer portion of this.
-            self.roll_buffer();
+    fn roll_buffer(&self) {
+        // Now roll the circular buffer portion of this.
+        let mut new = *self.cur.borrow() + 1;
+        if new >= self.state.len() {
+            *self.wrapped.borrow_mut() = true;
+            new = 0;
+        }
+        *self.cur.borrow_mut() = new;
+    }
+}
+
+impl Debug<String> {
+    fn debug(&self, s: String) {
+        let r = &*self.state[*self.cur.borrow()];
+        let _ = &*r.replace(s);
+        // Now roll the circular buffer portion of this.
+        self.roll_buffer();
+    }
+}
+
+impl Debug<CPUState> {
+    fn debug(&self) -> Rc<RefCell<CPUState>> {
+        let ret = Rc::clone(&self.state[*self.cur.borrow()]);
+
+        // Now roll the circular buffer portion of this.
+        self.roll_buffer();
+        ret
+    }
+}
+
+// tester is a wrapper around assert which is passed a `Debug` so any failure
+// will also print out the contents of the circular buffer prefixed by the error expression.
+macro_rules! tester {
+    ($test:expr, $dumper:ident, $error:expr) => {
+        assert!($test, "{}", $dumper.dump(&format!($error)))
+    };
+}
+
+const RESET: u16 = 0x1FFE;
+const IRQ_ADDR: u16 = 0xD001;
+
+fn setup(
+    t: Type,
+    hlt: u16,
+    fill: u8,
+    irq: Option<&'static dyn Sender>,
+    nmi: Option<&'static dyn Sender>,
+    debug_string: Option<&'static dyn Fn(String)>,
+    debug: Option<&'static dyn Fn() -> Rc<RefCell<CPUState>>>,
+) -> Cpu<'static> {
+    // NOTE: For tests only we simply put all this on the heap and then
+    //       leak things with leak so we can handle all the setup pieces.
+
+    // This should halt the cpu if a test goes off the rails since
+    // endless execution will eventually end up at the NMI vector (it's the first
+    // one) which contains HLT instructions.
+    let r = FlatRAM::new()
+        .vectors(Vectors {
+            nmi: hlt,
+            reset: RESET,
+            irq: IRQ_ADDR,
+        })
+        .fill_value(fill);
+    let mut r = Box::new(r);
+    r.power_on();
+
+    let def = Box::new(ChipDef {
+        cpu_type: t,
+        ram: Box::leak(r),
+        irq,
+        nmi,
+        rdy: None,
+    });
+
+    let mut cpu = Cpu::new(Box::leak(def));
+    cpu.set_debug_string(debug_string);
+    cpu.set_debug(debug);
+    cpu
+}
+
+fn step(cpu: &mut Cpu) -> Result<usize> {
+    let mut cycles = 0;
+    loop {
+        cpu.tick()?;
+        cpu.tick_done()?;
+        cycles += 1;
+        if cpu.op_tick == Tick::Reset {
+            break;
         }
     }
+    Ok(cycles)
+}
 
-    impl Debug<CPUState> {
-        fn debug(&self) -> Rc<RefCell<CPUState>> {
-            let ret = Rc::clone(&self.state[*self.cur.borrow()]);
+#[test]
+fn tick_next() {
+    let mut ticker = Tick::default();
 
-            // Now roll the circular buffer portion of this.
-            self.roll_buffer();
-            ret
-        }
-    }
-
-    // tester is a wrapper around assert which is passed a `Debug` so any failure
-    // will also print out the contents of the circular buffer prefixed by the error expression.
-    macro_rules! tester {
-        ($test:expr, $dumper:ident, $error:expr) => {
-            assert!($test, "{}", $dumper.dump(format!($error)))
-        };
-    }
-
-    const RESET: u16 = 0x1FFE;
-    const IRQ_ADDR: u16 = 0xD001;
-
-    fn setup(
-        t: Type,
-        hlt: u16,
-        fill: u8,
-        irq: Option<&'static dyn Sender>,
-        nmi: Option<&'static dyn Sender>,
-        debug_string: Option<&'static dyn Fn(String)>,
-        debug: Option<&'static dyn Fn() -> Rc<RefCell<CPUState>>>,
-    ) -> Box<Cpu<'static>> {
-        // NOTE: For tests only we simply put all this on the heap and then
-        //       leak things with leak so we can handle all the setup pieces.
-
-        // This should halt the cpu if a test goes off the rails since
-        // endless execution will eventually end up at the NMI vector (it's the first
-        // one) which contains HLT instructions.
-        let r = FlatRAM::new()
-            .vectors(Vectors {
-                nmi: hlt,
-                reset: RESET,
-                irq: IRQ_ADDR,
-            })
-            .fill_value(fill);
-        let mut r = Box::new(r);
-        r.power_on();
-
-        let def = Box::new(ChipDef {
-            cpu_type: t,
-            ram: Box::leak(r),
-            irq: irq,
-            nmi: nmi,
-            rdy: None,
-        });
-
-        let mut cpu = Box::new(Cpu::new(Box::leak(def)));
-        cpu.set_debug_string(debug_string);
-        cpu.set_debug(debug);
-        cpu
-    }
-
-    fn step(cpu: &mut Cpu) -> Result<usize> {
-        let mut cycles = 0;
-        loop {
-            cpu.tick()?;
-            cpu.tick_done()?;
-            cycles += 1;
-            if cpu.op_tick == Tick::Reset {
-                break;
-            }
-        }
-        Ok(cycles)
-    }
-
-    #[test]
-    fn tick_next() -> Result<()> {
-        let mut ticker = Tick::default();
-
-        assert!(ticker == Tick::Reset, "not in valid reset state");
-        // Validate when we get to the end it stays on it
-        loop {
-            ticker = ticker.next();
-            if ticker == Tick::Tick7 {
-                break;
-            }
-        }
+    assert!(ticker == Tick::Reset, "not in valid reset state");
+    // Validate when we get to the end it stays on it
+    loop {
         ticker = ticker.next();
-        assert!(ticker == Tick::Tick8, "didn't advance to tick8");
-        ticker = ticker.next();
-        assert!(ticker == Tick::Tick8, "didn't continue to stay in tick8");
-        Ok(())
+        if ticker == Tick::Tick7 {
+            break;
+        }
     }
+    ticker = ticker.next();
+    assert!(ticker == Tick::Tick8, "didn't advance to tick8");
+    ticker = ticker.next();
+    assert!(ticker == Tick::Tick8, "didn't continue to stay in tick8");
+}
 
-    macro_rules! init_test {
+macro_rules! init_test {
         ($suite:ident, $($name:ident: $type:expr, $rand:expr,)*) => {
             mod $suite {
                 use super::*;
@@ -215,19 +212,19 @@ mod tests {
         }
     }
 
-    init_test!(
-        init_tests,
-        nmos: Type::NMOS,
-        true,
-        ricoh: Type::Ricoh,
-        false,
-        nmos6510: Type::NMOS6510,
-        true,
-        cmos: Type::CMOS,
-        false,
-    );
+init_test!(
+    init_tests,
+    nmos: Type::NMOS,
+    true,
+    ricoh: Type::Ricoh,
+    false,
+    nmos6510: Type::NMOS6510,
+    true,
+    cmos: Type::CMOS,
+    false,
+);
 
-    macro_rules! tick_test {
+macro_rules! tick_test {
         ($suite:ident, $($name:ident: $type:expr,)*) => {
             mod $suite {
                 use super::*;
@@ -283,23 +280,23 @@ mod tests {
         }
     }
 
-    tick_test!(
-        tick_tests,
-        nmos: Type::NMOS,
-        ricoh: Type::Ricoh,
-        nmos6510: Type::NMOS6510,
-        //   cmos: Type::CMOS,
-    );
+tick_test!(
+    tick_tests,
+    nmos: Type::NMOS,
+    ricoh: Type::Ricoh,
+    nmos6510: Type::NMOS6510,
+    //   cmos: Type::CMOS,
+);
 
-    #[derive(Debug)]
-    struct NopHltTest {
-        fill: u8,
-        halt: u8,
-        cycles: usize,
-        bump: u8,
-    }
+#[derive(Debug)]
+struct NopHltTest {
+    fill: u8,
+    halt: u8,
+    cycles: usize,
+    bump: u8,
+}
 
-    macro_rules! nop_hlt_test {
+macro_rules! nop_hlt_test {
         ($suite:ident, $($name:ident: $test:expr)*) => {
             mod $suite {
                 use super::*;
@@ -343,12 +340,7 @@ mod tests {
                         loop {
                             let pc = cpu.pc;
                             ret = step(&mut cpu);
-                            let cycles = match(ret) {
-                                Ok(c) => c,
-                                _ => {
-                                    break;
-                                }
-                            };
+                            let Ok(cycles) = ret else { break; };
                             tot += cycles;
 
                             if cycles != test.cycles {
@@ -413,50 +405,50 @@ mod tests {
         }
     }
 
-    nop_hlt_test!(
-        nop_hlt_tests,
-        classic_nop_0x02_hlt: NopHltTest{fill: 0xEA, halt: 0x02, cycles: 2, bump: 1}
-        classic_nop_0x12_hlt: NopHltTest{fill: 0xEA, halt: 0x12, cycles: 2, bump: 1}
-        classic_nop_0x22_hlt: NopHltTest{fill: 0xEA, halt: 0x22, cycles: 2, bump: 1}
-        classic_nop_0x32_hlt: NopHltTest{fill: 0xEA, halt: 0x32, cycles: 2, bump: 1}
-        classic_nop_0x42_hlt: NopHltTest{fill: 0xEA, halt: 0x42, cycles: 2, bump: 1}
-        classic_nop_0x52_hlt: NopHltTest{fill: 0xEA, halt: 0x52, cycles: 2, bump: 1}
-        classic_nop_0x62_hlt: NopHltTest{fill: 0xEA, halt: 0x62, cycles: 2, bump: 1}
-        classic_nop_0x72_hlt: NopHltTest{fill: 0xEA, halt: 0x72, cycles: 2, bump: 1}
-        classic_nop_0x92_hlt: NopHltTest{fill: 0xEA, halt: 0x92, cycles: 2, bump: 1}
-        classic_nop_0xb2_hlt: NopHltTest{fill: 0xEA, halt: 0xB2, cycles: 2, bump: 1}
-        classic_nop_0xd2_hlt: NopHltTest{fill: 0xEA, halt: 0xD2, cycles: 2, bump: 1}
-        classic_nop_0xf2_hlt: NopHltTest{fill: 0xEA, halt: 0xF2, cycles: 2, bump: 1}
-        nop_0x04_hlt_0x12: NopHltTest{fill: 0x04, halt: 0x12, cycles: 3, bump: 2}
-        nop_0x0c_hlt_0x12: NopHltTest{fill: 0x0C, halt: 0x12, cycles: 4, bump: 3}
-        nop_0x14_hlt_0x12: NopHltTest{fill: 0x14, halt: 0x12, cycles: 4, bump: 2}
-        nop_0x1a_hlt_0x12: NopHltTest{fill: 0x1A, halt: 0x12, cycles: 2, bump: 1}
-        nop_0x1c_hlt_0x12: NopHltTest{fill: 0x1C, halt: 0x12, cycles: 4, bump: 3}
-        nop_0x34_hlt_0x12: NopHltTest{fill: 0x34, halt: 0x12, cycles: 3, bump: 2}
-        nop_0x3a_hlt_0x12: NopHltTest{fill: 0x3A, halt: 0x12, cycles: 2, bump: 1}
-        nop_0x3c_hlt_0x12: NopHltTest{fill: 0x3C, halt: 0x12, cycles: 4, bump: 3}
-        nop_0x44_hlt_0x12: NopHltTest{fill: 0x44, halt: 0x12, cycles: 3, bump: 2}
-        nop_0x54_hlt_0x12: NopHltTest{fill: 0x54, halt: 0x12, cycles: 4, bump: 2}
-        nop_0x5a_hlt_0x12: NopHltTest{fill: 0x5A, halt: 0x12, cycles: 2, bump: 1}
-        nop_0x5c_hlt_0x12: NopHltTest{fill: 0x5C, halt: 0x12, cycles: 4, bump: 3}
-        nop_0x64_hlt_0x12: NopHltTest{fill: 0x64, halt: 0x12, cycles: 3, bump: 2}
-        nop_0x74_hlt_0x12: NopHltTest{fill: 0x74, halt: 0x12, cycles: 4, bump: 2}
-        nop_0x7a_hlt_0x12: NopHltTest{fill: 0x7A, halt: 0x12, cycles: 2, bump: 1}
-        nop_0x7c_hlt_0x12: NopHltTest{fill: 0x7C, halt: 0x12, cycles: 4, bump: 3}
-        nop_0x80_hlt_0x12: NopHltTest{fill: 0x80, halt: 0x12, cycles: 2, bump: 2}
-        nop_0x82_hlt_0x12: NopHltTest{fill: 0x82, halt: 0x12, cycles: 2, bump: 2}
-        nop_0x89_hlt_0x12: NopHltTest{fill: 0x89, halt: 0x12, cycles: 2, bump: 2}
-        nop_0xc2_hlt_0x12: NopHltTest{fill: 0xC2, halt: 0x12, cycles: 2, bump: 2}
-        nop_0xd4_hlt_0x12: NopHltTest{fill: 0xD4, halt: 0x12, cycles: 4, bump: 2}
-        nop_0xda_hlt_0x12: NopHltTest{fill: 0xDA, halt: 0x12, cycles: 2, bump: 1}
-        nop_0xdc_hlt_0x12: NopHltTest{fill: 0xDC, halt: 0x12, cycles: 4, bump: 3}
-        nop_0xe2_hlt_0x12: NopHltTest{fill: 0xE2, halt: 0x12, cycles: 2, bump: 2}
-        nop_0xf4_hlt_0x12: NopHltTest{fill: 0xF4, halt: 0x12, cycles: 4, bump: 2}
-        nop_0xfa_hlt_0x12: NopHltTest{fill: 0xFA, halt: 0x12, cycles: 2, bump: 1}
-        nop_0xfc_hlt_0x12: NopHltTest{fill: 0xFC, halt: 0x12, cycles: 4, bump: 3}
-    );
+nop_hlt_test!(
+    nop_hlt_tests,
+    classic_nop_0x02_hlt: NopHltTest{fill: 0xEA, halt: 0x02, cycles: 2, bump: 1}
+    classic_nop_0x12_hlt: NopHltTest{fill: 0xEA, halt: 0x12, cycles: 2, bump: 1}
+    classic_nop_0x22_hlt: NopHltTest{fill: 0xEA, halt: 0x22, cycles: 2, bump: 1}
+    classic_nop_0x32_hlt: NopHltTest{fill: 0xEA, halt: 0x32, cycles: 2, bump: 1}
+    classic_nop_0x42_hlt: NopHltTest{fill: 0xEA, halt: 0x42, cycles: 2, bump: 1}
+    classic_nop_0x52_hlt: NopHltTest{fill: 0xEA, halt: 0x52, cycles: 2, bump: 1}
+    classic_nop_0x62_hlt: NopHltTest{fill: 0xEA, halt: 0x62, cycles: 2, bump: 1}
+    classic_nop_0x72_hlt: NopHltTest{fill: 0xEA, halt: 0x72, cycles: 2, bump: 1}
+    classic_nop_0x92_hlt: NopHltTest{fill: 0xEA, halt: 0x92, cycles: 2, bump: 1}
+    classic_nop_0xb2_hlt: NopHltTest{fill: 0xEA, halt: 0xB2, cycles: 2, bump: 1}
+    classic_nop_0xd2_hlt: NopHltTest{fill: 0xEA, halt: 0xD2, cycles: 2, bump: 1}
+    classic_nop_0xf2_hlt: NopHltTest{fill: 0xEA, halt: 0xF2, cycles: 2, bump: 1}
+    nop_0x04_hlt_0x12: NopHltTest{fill: 0x04, halt: 0x12, cycles: 3, bump: 2}
+    nop_0x0c_hlt_0x12: NopHltTest{fill: 0x0C, halt: 0x12, cycles: 4, bump: 3}
+    nop_0x14_hlt_0x12: NopHltTest{fill: 0x14, halt: 0x12, cycles: 4, bump: 2}
+    nop_0x1a_hlt_0x12: NopHltTest{fill: 0x1A, halt: 0x12, cycles: 2, bump: 1}
+    nop_0x1c_hlt_0x12: NopHltTest{fill: 0x1C, halt: 0x12, cycles: 4, bump: 3}
+    nop_0x34_hlt_0x12: NopHltTest{fill: 0x34, halt: 0x12, cycles: 3, bump: 2}
+    nop_0x3a_hlt_0x12: NopHltTest{fill: 0x3A, halt: 0x12, cycles: 2, bump: 1}
+    nop_0x3c_hlt_0x12: NopHltTest{fill: 0x3C, halt: 0x12, cycles: 4, bump: 3}
+    nop_0x44_hlt_0x12: NopHltTest{fill: 0x44, halt: 0x12, cycles: 3, bump: 2}
+    nop_0x54_hlt_0x12: NopHltTest{fill: 0x54, halt: 0x12, cycles: 4, bump: 2}
+    nop_0x5a_hlt_0x12: NopHltTest{fill: 0x5A, halt: 0x12, cycles: 2, bump: 1}
+    nop_0x5c_hlt_0x12: NopHltTest{fill: 0x5C, halt: 0x12, cycles: 4, bump: 3}
+    nop_0x64_hlt_0x12: NopHltTest{fill: 0x64, halt: 0x12, cycles: 3, bump: 2}
+    nop_0x74_hlt_0x12: NopHltTest{fill: 0x74, halt: 0x12, cycles: 4, bump: 2}
+    nop_0x7a_hlt_0x12: NopHltTest{fill: 0x7A, halt: 0x12, cycles: 2, bump: 1}
+    nop_0x7c_hlt_0x12: NopHltTest{fill: 0x7C, halt: 0x12, cycles: 4, bump: 3}
+    nop_0x80_hlt_0x12: NopHltTest{fill: 0x80, halt: 0x12, cycles: 2, bump: 2}
+    nop_0x82_hlt_0x12: NopHltTest{fill: 0x82, halt: 0x12, cycles: 2, bump: 2}
+    nop_0x89_hlt_0x12: NopHltTest{fill: 0x89, halt: 0x12, cycles: 2, bump: 2}
+    nop_0xc2_hlt_0x12: NopHltTest{fill: 0xC2, halt: 0x12, cycles: 2, bump: 2}
+    nop_0xd4_hlt_0x12: NopHltTest{fill: 0xD4, halt: 0x12, cycles: 4, bump: 2}
+    nop_0xda_hlt_0x12: NopHltTest{fill: 0xDA, halt: 0x12, cycles: 2, bump: 1}
+    nop_0xdc_hlt_0x12: NopHltTest{fill: 0xDC, halt: 0x12, cycles: 4, bump: 3}
+    nop_0xe2_hlt_0x12: NopHltTest{fill: 0xE2, halt: 0x12, cycles: 2, bump: 2}
+    nop_0xf4_hlt_0x12: NopHltTest{fill: 0xF4, halt: 0x12, cycles: 4, bump: 2}
+    nop_0xfa_hlt_0x12: NopHltTest{fill: 0xFA, halt: 0x12, cycles: 2, bump: 1}
+    nop_0xfc_hlt_0x12: NopHltTest{fill: 0xFC, halt: 0x12, cycles: 4, bump: 3}
+);
 
-    macro_rules! load_test {
+macro_rules! load_test {
         ($suite:ident, $($name:ident: $x:expr, $expected:expr)*) => {
             mod $suite {
                 use super::*;
@@ -539,13 +531,13 @@ mod tests {
         }
     }
 
-    load_test!(
-        load_tests,
-        x_is_zero: 0x00, vec![0xAB, 0xEF]
-        x_is_10: 0x10, vec![0xCD, 0x00]
-    );
+load_test!(
+    load_tests,
+    x_is_zero: 0x00, vec![0xAB, 0xEF]
+    x_is_10: 0x10, vec![0xCD, 0x00]
+);
 
-    macro_rules! store_test {
+macro_rules! store_test {
         ($suite:ident, $($name:ident: $a:expr, $x:expr, $expected:expr)*) => {
             mod $suite {
                 use super::*;
@@ -620,341 +612,342 @@ mod tests {
         }
     }
 
-    store_test!(
-        store_tests,
-        x_is_zero: 0xAA, 0x00, vec![0x650F, 0xA1FA]
-        x_is_10: 0x55, 0x10, vec![0x551F, 0xA20A]
+store_test!(
+    store_tests,
+    x_is_zero: 0xAA, 0x00, vec![0x650F, 0xA1FA]
+    x_is_10: 0x55, 0x10, vec![0x551F, 0xA20A]
+);
+
+struct Irq {
+    raised: RefCell<bool>,
+}
+
+impl Sender for Irq {
+    fn raised(&self) -> bool {
+        *self.raised.borrow()
+    }
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn irq_and_nmi() -> Result<()> {
+    // This test is little more serial and long than other tests as the corner cases with
+    // interrupt handling only occur when triggered on specific ticks and while in certain states.
+    // So this has to be done clock by clock and conditions checked at each.
+
+    let nmi: u16 = 0x0202; // If executed should halt the processor but we'll put code at this PC.
+    let i = Box::leak(Box::new(Irq {
+        raised: RefCell::new(false),
+    }));
+    let n = Box::leak(Box::new(Irq {
+        raised: RefCell::new(false),
+    }));
+
+    // TODO(jchacon): Make this a macro so we can test for CMOS too and the D bit flips.
+    let d = Box::leak(Box::new(Debug::<String>::new(128)));
+    let debug = Box::leak(Box::new(|s| d.debug(s)));
+    let mut cpu = setup(Type::NMOS, nmi, 0xEA, Some(i), Some(n), Some(debug), None);
+    cpu.power_on()?;
+
+    cpu.ram.write(IRQ_ADDR, 0x69); // ADC #AB
+    cpu.ram.write(IRQ_ADDR + 1, 0xAB);
+    cpu.ram.write(IRQ_ADDR + 2, 0x40); // RTI
+    cpu.ram.write(nmi, 0x40); // RTI
+    cpu.ram.write(RESET, 0xEA); // NOP
+    cpu.ram.write(RESET + 1, 0x00); // BRK #00
+    cpu.ram.write(RESET + 2, 0x00);
+    cpu.ram.write(RESET + 3, 0xD0); // BNE +2
+    cpu.ram.write(RESET + 4, 0x00);
+    cpu.ram.write(RESET + 5, 0xD0); // BNE +2
+    cpu.ram.write(RESET + 6, 0x00);
+
+    // Set D on up front and I off
+    cpu.p |= P_DECIMAL;
+    cpu.p &= !P_INTERRUPT;
+
+    // Set A to 0
+    cpu.a = Wrapping(0x00);
+
+    // Now wrap this into a RefCell so we can create verify below and use it mutablely there
+    // but still be able to peek inside to check other invariants later.
+    let wrapped_cpu = RefCell::new(cpu);
+
+    // Save a copy of P so we can compare
+    let saved_p = wrapped_cpu.borrow().p;
+
+    let verify = |irq: bool, nmi: bool, state: &str, done: bool| -> Result<()> {
+        *i.raised.borrow_mut() = irq;
+        *n.raised.borrow_mut() = nmi;
+
+        // We don't use Step because we want to inspect/change things on a per tick basis.
+        let c = wrapped_cpu.borrow();
+        println!("pre: {state} tick: {} irq: {irq} nmi: {nmi} done: {done} irq_raised: {} skip: {} interrupt_state: {}", c.op_tick, c.irq_raised, c.skip_interrupt, c.interrupt_state);
+        drop(c);
+        wrapped_cpu.borrow_mut().tick()?;
+        wrapped_cpu.borrow_mut().tick_done()?;
+        let c = wrapped_cpu.borrow();
+        println!("post: {state} tick: {} irq: {irq} nmi: {nmi} done: {done} irq_raised: {} skip: {} interrupt_state: {}", c.op_tick, c.irq_raised, c.skip_interrupt, c.interrupt_state);
+        Ok(())
+    };
+
+    verify(false, false, "First NOP", false)?;
+
+    // IRQ but should finish instruction and set PC to RESET+1
+    let state = "2nd NOP";
+    verify(true, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 1;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    // Verify P still has S1 and D set
+    let got = wrapped_cpu.borrow().p;
+    let want = Flags(P_S1 | P_DECIMAL);
+    tester!(got == want, d, "{state}: got wrong flags {got} want {want}");
+
+    // Don't assert IRQ anymore as should be cached state. Also this should take 7 cycles.
+    let state = "IRQ setup";
+    for _ in 0..6 {
+        verify(false, false, state, false)?;
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = IRQ_ADDR;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    // Verify the only things set in flags right now are S1 and I and D. D shouldn't be cleared for NMOS.
+    let got = wrapped_cpu.borrow().p;
+    let want = Flags(P_S1 | P_INTERRUPT | P_DECIMAL);
+    tester!(got == want, d, "{state}: got wrong flags {got} want {want}");
+    tester!(
+        wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
+        d,
+        "{state}: IRQ wasn't cleared after run"
+    );
+    tester!(
+        wrapped_cpu.borrow().interrupt_state == InterruptState::None,
+        d,
+        "{state}: running interrupt still?"
     );
 
-    struct Irq {
-        raised: RefCell<bool>,
-    }
+    // Pull P off the stack and verify the B bit didn't get set.
+    let c = wrapped_cpu.borrow();
+    let addr = (c.s + Wrapping(1)).0;
+    let got = Flags(c.ram.read(u16::from(addr) + STACK_START));
+    tester!(
+        got == saved_p,
+        d,
+        "{state}: flags aren't correct. Didn't match original. got {got} want {saved_p}"
+    );
+    drop(c);
 
-    impl Sender for Irq {
-        fn raised(&self) -> bool {
-            *self.raised.borrow()
-        }
-    }
+    // Now set IRQ. Should still let this instruction finish since the first instruction
+    // of a handler always completes before we trigger another handler.
+    let state = "ADC #AB";
+    verify(true, false, state, false)?;
+    // Now set NMI also and it should win.
+    verify(true, true, state, true)?;
+    let got = wrapped_cpu.borrow().a.0;
+    let want = 0x11; // TODO(jchacon): 0xAB for non BCD
+    tester!(
+        got == want,
+        d,
+        "{state}: A doesn't match. got {got:02X} and want {want:02X}"
+    );
 
-    #[test]
-    fn irq_and_nmi() -> Result<()> {
-        // This test is little more serial and long than other tests as the corner cases with
-        // interrupt handling only occur when triggered on specific ticks and while in certain states.
-        // So this has to be done clock by clock and conditions checked at each.
-
-        let nmi: u16 = 0x0202; // If executed should halt the processor but we'll put code at this PC.
-        let i = Box::leak(Box::new(Irq {
-            raised: RefCell::new(false),
-        }));
-        let n = Box::leak(Box::new(Irq {
-            raised: RefCell::new(false),
-        }));
-
-        // TODO(jchacon): Make this a macro so we can test for CMOS too and the D bit flips.
-        let d = Box::leak(Box::new(Debug::<String>::new(128)));
-        let debug = Box::leak(Box::new(|s| d.debug(s)));
-        let mut cpu = setup(Type::NMOS, nmi, 0xEA, Some(i), Some(n), Some(debug), None);
-        cpu.power_on()?;
-
-        cpu.ram.write(IRQ_ADDR, 0x69); // ADC #AB
-        cpu.ram.write(IRQ_ADDR + 1, 0xAB);
-        cpu.ram.write(IRQ_ADDR + 2, 0x40); // RTI
-        cpu.ram.write(nmi, 0x40); // RTI
-        cpu.ram.write(RESET, 0xEA); // NOP
-        cpu.ram.write(RESET + 1, 0x00); // BRK #00
-        cpu.ram.write(RESET + 2, 0x00);
-        cpu.ram.write(RESET + 3, 0xD0); // BNE +2
-        cpu.ram.write(RESET + 4, 0x00);
-        cpu.ram.write(RESET + 5, 0xD0); // BNE +2
-        cpu.ram.write(RESET + 6, 0x00);
-
-        // Set D on up front and I off
-        cpu.p |= P_DECIMAL;
-        cpu.p &= !P_INTERRUPT;
-
-        // Set A to 0
-        cpu.a = Wrapping(0x00);
-
-        // Now wrap this into a RefCell so we can create verify below and use it mutablely there
-        // but still be able to peek inside to check other invariants later.
-        let wrapped_cpu = RefCell::new(cpu);
-
-        // Save a copy of P so we can compare
-        let saved_p = wrapped_cpu.borrow().p;
-
-        let verify = |irq: bool, nmi: bool, state: &str, done: bool| -> Result<()> {
-            *i.raised.borrow_mut() = irq;
-            *n.raised.borrow_mut() = nmi;
-
-            // We don't use Step because we want to inspect/change things on a per tick basis.
-            let c = wrapped_cpu.borrow();
-            println!("pre: {state} tick: {} irq: {irq} nmi: {nmi} done: {done} irq_raised: {} skip: {} interrupt_state: {}", c.op_tick, c.irq_raised, c.skip_interrupt, c.interrupt_state);
-            drop(c);
-            wrapped_cpu.borrow_mut().tick()?;
-            wrapped_cpu.borrow_mut().tick_done()?;
-            let c = wrapped_cpu.borrow();
-            println!("post: {state} tick: {} irq: {irq} nmi: {nmi} done: {done} irq_raised: {} skip: {} interrupt_state: {}", c.op_tick, c.irq_raised, c.skip_interrupt, c.interrupt_state);
-            Ok(())
-        };
-
-        verify(false, false, "First NOP", false)?;
-
-        // IRQ but should finish instruction and set PC to RESET+1
-        let state = "2nd NOP";
-        verify(true, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 1;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        // Verify P still has S1 and D set
-        let got = wrapped_cpu.borrow().p;
-        let want = Flags(P_S1 | P_DECIMAL);
-        tester!(got == want, d, "{state}: got wrong flags {got} want {want}");
-
-        // Don't assert IRQ anymore as should be cached state. Also this should take 7 cycles.
-        let state = "IRQ setup";
-        for _ in 0..6 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = IRQ_ADDR;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        // Verify the only things set in flags right now are S1 and I and D. D shouldn't be cleared for NMOS.
-        let got = wrapped_cpu.borrow().p;
-        let want = Flags(P_S1 | P_INTERRUPT | P_DECIMAL);
-        tester!(got == want, d, "{state}: got wrong flags {got} want {want}");
-        tester!(
-            wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
-            d,
-            "{state}: IRQ wasn't cleared after run"
-        );
-        tester!(
-            wrapped_cpu.borrow().interrupt_state == InterruptState::None,
-            d,
-            "{state}: running interrupt still?"
-        );
-
-        // Pull P off the stack and verify the B bit didn't get set.
-        let c = wrapped_cpu.borrow();
-        let addr = (c.s + Wrapping(1)).0;
-        let got = Flags(c.ram.read(u16::from(addr) + STACK_START));
-        tester!(
-            got == saved_p,
-            d,
-            "{state}: flags aren't correct. Didn't match original. got {got} want {saved_p}"
-        );
-        drop(c);
-
-        // Now set IRQ. Should still let this instruction finish since the first instruction
-        // of a handler always completes before we trigger another handler.
-        let state = "ADC #AB";
-        verify(true, false, state, false)?;
-        // Now set NMI also and it should win.
-        verify(true, true, state, true)?;
-        let got = wrapped_cpu.borrow().a.0;
-        let want = 0x11; // TODO(jchacon): 0xAB for non BCD
-        tester!(
-            got == want,
-            d,
-            "{state}: A doesn't match. got {got:02X} and want {want:02X}"
-        );
-
-        // NMI setup takes 7 cycles too.
-        let state = "NMI setup";
-        for _ in 0..6 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = nmi;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        tester!(
-            wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
-            d,
-            "{state}: IRQ wasn't cleared after run"
-        );
-        tester!(
-            wrapped_cpu.borrow().interrupt_state == InterruptState::None,
-            d,
-            "{state}: running interrupt still?"
-        );
-
-        // Should be an RTI that takes 6 cycles
-        let state = "First RTI";
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = IRQ_ADDR + 2;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-
-        // Another RTI
-        let state = "Second RTI";
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 1;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        let got = wrapped_cpu.borrow().p;
-        tester!(
-            got == saved_p,
-            d,
-            "{state}: flags didn't reset got {got} and want {saved_p}"
-        );
-
-        // Start running BRK and interrupt part wayn through (with NMI) which should complete BRK
-        // but skip it upon return. This means running 5 ticks normally.
-        let state = "BRK";
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        // Now set NMI
-        verify(false, true, state, false)?;
-        // Now should jump
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = nmi;
-        tester!(got == want, d, "{state}: Got wrong PC {got} want {want}");
-        // Pull P off the stack and verify the B bit did get set even though we're in an NMI handler.
-        let addr = (wrapped_cpu.borrow().s + Wrapping(1)).0;
-        let got = Flags(wrapped_cpu.borrow().ram.read(STACK_START + u16::from(addr)));
-        let want = saved_p | P_B;
-        let c = wrapped_cpu.borrow();
-        tester!(got == want, d, "{state}: Flags aren't correct. Don't include P_B even for NMI. Got {got} and want {want} - cpu: {c}");
-        drop(c);
-        tester!(
-            wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
-            d,
-            "{state}: IRQ wasn't cleared after run"
-        );
-        tester!(
-            wrapped_cpu.borrow().interrupt_state == InterruptState::None,
-            d,
-            "{state}: running interrupt still?"
-        );
-
-        // Yet another RTI
-        let state = "3rd RTI";
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 3;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-
-        // Now we're going to run BNE+2 (so the next instruction) and set NMI in the middle of it.
-        // It shoudn't start that processing until after this and the next instruction.
-        // These take 3 cycles since they aren't page boundary crossing.
-        let state = "1st BNE";
+    // NMI setup takes 7 cycles too.
+    let state = "NMI setup";
+    for _ in 0..6 {
         verify(false, false, state, false)?;
-        verify(false, true, state, false)?;
-        verify(false, false, state, true)?;
-        // PC should have advanced to the next instruction.
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 5;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        // And it should advance again into the next instruction.
-        let state = "2nd BNE";
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = nmi;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    tester!(
+        wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
+        d,
+        "{state}: IRQ wasn't cleared after run"
+    );
+    tester!(
+        wrapped_cpu.borrow().interrupt_state == InterruptState::None,
+        d,
+        "{state}: running interrupt still?"
+    );
+
+    // Should be an RTI that takes 6 cycles
+    let state = "First RTI";
+    for _ in 0..5 {
         verify(false, false, state, false)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 6;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-        // And then finish with NMI set again but it won't skip this time.
-        verify(false, true, state, false)?;
-        verify(false, false, state, true)?;
-        // Now it should start an NMI
-        let state = "2nd NMI setup";
-        for _ in 0..6 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = nmi;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-
-        // Should be another RTI
-        let state = "4th RTI";
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = RESET + 7;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-
-        // Finally fire off an NMI at the start of this NOP which should immediately run the interrupt.
-        let state = "3rd NMI setup";
-        verify(false, true, state, false)?;
-        for _ in 0..5 {
-            verify(false, false, state, false)?;
-        }
-        verify(false, false, state, true)?;
-        let got = wrapped_cpu.borrow().pc.0;
-        let want = nmi;
-        tester!(
-            got == want,
-            d,
-            "{state}: got wrong PC {got:04X} want {want:04X}"
-        );
-
-        Ok(())
     }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = IRQ_ADDR + 2;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
 
-    struct RomTest<'a> {
-        filename: &'a str,
-        cpu: Type,
-        start_pc: u16,
-        end_check: fn(u16, &Cpu) -> bool,
-        success_check: fn(u16, &Cpu) -> Result<()>,
-        expected_cycles: Option<usize>,
-        expected_instructions: Option<usize>,
+    // Another RTI
+    let state = "Second RTI";
+    for _ in 0..5 {
+        verify(false, false, state, false)?;
     }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 1;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    let got = wrapped_cpu.borrow().p;
+    tester!(
+        got == saved_p,
+        d,
+        "{state}: flags didn't reset got {got} and want {saved_p}"
+    );
 
-    macro_rules! rom_test {
+    // Start running BRK and interrupt part wayn through (with NMI) which should complete BRK
+    // but skip it upon return. This means running 5 ticks normally.
+    let state = "BRK";
+    for _ in 0..5 {
+        verify(false, false, state, false)?;
+    }
+    // Now set NMI
+    verify(false, true, state, false)?;
+    // Now should jump
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = nmi;
+    tester!(got == want, d, "{state}: Got wrong PC {got} want {want}");
+    // Pull P off the stack and verify the B bit did get set even though we're in an NMI handler.
+    let addr = (wrapped_cpu.borrow().s + Wrapping(1)).0;
+    let got = Flags(wrapped_cpu.borrow().ram.read(STACK_START + u16::from(addr)));
+    let want = saved_p | P_B;
+    let c = wrapped_cpu.borrow();
+    tester!(got == want, d, "{state}: Flags aren't correct. Don't include P_B even for NMI. Got {got} and want {want} - cpu: {c}");
+    drop(c);
+    tester!(
+        wrapped_cpu.borrow().irq_raised == InterruptStyle::None,
+        d,
+        "{state}: IRQ wasn't cleared after run"
+    );
+    tester!(
+        wrapped_cpu.borrow().interrupt_state == InterruptState::None,
+        d,
+        "{state}: running interrupt still?"
+    );
+
+    // Yet another RTI
+    let state = "3rd RTI";
+    for _ in 0..5 {
+        verify(false, false, state, false)?;
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 3;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+
+    // Now we're going to run BNE+2 (so the next instruction) and set NMI in the middle of it.
+    // It shoudn't start that processing until after this and the next instruction.
+    // These take 3 cycles since they aren't page boundary crossing.
+    let state = "1st BNE";
+    verify(false, false, state, false)?;
+    verify(false, true, state, false)?;
+    verify(false, false, state, true)?;
+    // PC should have advanced to the next instruction.
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 5;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    // And it should advance again into the next instruction.
+    let state = "2nd BNE";
+    verify(false, false, state, false)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 6;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+    // And then finish with NMI set again but it won't skip this time.
+    verify(false, true, state, false)?;
+    verify(false, false, state, true)?;
+    // Now it should start an NMI
+    let state = "2nd NMI setup";
+    for _ in 0..6 {
+        verify(false, false, state, false)?;
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = nmi;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+
+    // Should be another RTI
+    let state = "4th RTI";
+    for _ in 0..5 {
+        verify(false, false, state, false)?;
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = RESET + 7;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+
+    // Finally fire off an NMI at the start of this NOP which should immediately run the interrupt.
+    let state = "3rd NMI setup";
+    verify(false, true, state, false)?;
+    for _ in 0..5 {
+        verify(false, false, state, false)?;
+    }
+    verify(false, false, state, true)?;
+    let got = wrapped_cpu.borrow().pc.0;
+    let want = nmi;
+    tester!(
+        got == want,
+        d,
+        "{state}: got wrong PC {got:04X} want {want:04X}"
+    );
+
+    Ok(())
+}
+
+struct RomTest<'a> {
+    filename: &'a str,
+    cpu: Type,
+    start_pc: u16,
+    end_check: fn(u16, &Cpu) -> bool,
+    success_check: fn(u16, &Cpu) -> Result<()>,
+    expected_cycles: Option<usize>,
+    expected_instructions: Option<usize>,
+}
+
+macro_rules! rom_test {
         ($suite:ident, $($name:ident: $rom_test:expr)*) => {
             mod $suite {
                 use super::*;
@@ -1024,209 +1017,208 @@ mod tests {
         }
     }
 
-    rom_test!(
-        rom_tests,
-        functional_test: RomTest{
-            filename: "6502_functional_test.bin",
-            cpu: Type::NMOS,
-            start_pc: 0x0400,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0x3469 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(96241367),
-            expected_instructions: Some(30646177),
-        }
-        // The next tests (up to and including vsbx.bin) all come from http://nesdev.com/6502_cpu.txt
-        // NOTE: They are hard to debug even with the ring buffer since we don't snapshot memory
-        //       state and the test itself is self modifying code...So you'll have to use the register values
-        //       to infer state along the way.
-        dadc_test: RomTest{
-            filename: "dadc.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(21230741),
-            expected_instructions: Some(8109022),
-        }
-        dincsbc_test: RomTest{
-            filename: "dincsbc.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(18939481),
-            expected_instructions: Some(6781980),
-        }
-        dincsbc_deccmp_test: RomTest{
-            filename: "dincsbc-deccmp.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(18095480),
-            expected_instructions: Some(5507189),
-        }
-        droradc_test: RomTest{
-            filename: "droradc.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(22148245),
-            expected_instructions: Some(8240094),
-        }
-        dsbc_test: RomTest{
-            filename: "dsbc.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(18021977),
-            expected_instructions: Some(6650908),
-        }
-        dsbc_cmp_flags_test: RomTest{
-            filename: "dsbc-cmp-flags.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(14425356),
-            expected_instructions: Some(4982869),
-        }
-        sbx_test: RomTest{
-            filename: "sbx.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                if old == cpu.pc.0 {
-                    println!("");
-                    return true
-                }
-                // On this test it JSR's to FFD2 which is the C64
-                // ROM print routine. It prints a dot for each iteration.
-                // Do the same for easier debugging if it fails.
-                if cpu.pc.0 == 0xFFd2 {
-                    print!(".");
-                }
-                false
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(6044288253),
-            expected_instructions: Some(2081694800),
-        }
-        vsbx_test: RomTest{
-            filename: "vsbx.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xD000,
-            end_check: |old, cpu| {
-                if old == cpu.pc.0 {
-                    println!("");
-                    return true
-                }
-                // On this test it JSR's to FFD2 which is the C64
-                // ROM print routine. It prints a dot for each iteration.
-                // Do the same for easier debugging if it fails.
-                if cpu.pc.0 == 0xFFd2 {
-                    print!(".");
-                }
-                false
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xD004 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            expected_cycles: Some(7525173529),
-            expected_instructions: Some(2552776790),
-        }
-        bcd_test: RomTest{
-            filename: "bcd_test.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xC000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0 || old == 0xC04B
-            },
-            success_check: |_old, cpu| {
-                let val = cpu.ram.read(0x0000);
-                if val != 0x00 {
-                    return Err(eyre!("Invalid value at 0x0000: Got {val:2X} and want 0x00"))
-                }
+rom_test!(
+    rom_tests,
+    functional_test: RomTest{
+        filename: "6502_functional_test.bin",
+        cpu: Type::NMOS,
+        start_pc: 0x0400,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0x3469 {
                 return Ok(());
-            },
-            expected_cycles: Some(53953828),
-            expected_instructions: Some(17609916),
-        }
-        undocumented_opcodes_test: RomTest{
-            filename: "undocumented.bin",
-            cpu: Type::NMOS,
-            start_pc: 0xC000,
-            end_check: |old, cpu| {
-                old == cpu.pc.0
-            },
-            success_check: |_old, cpu| {
-                if cpu.pc.0 == 0xC123 {
-                    return Ok(());
-                }
-                Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
-            },
-            // No expected cycles/instructions because OAL can generate different paths.
-            expected_cycles: None,
-            expected_instructions: None,
-        }
-    );
-}
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(96_241_367),
+        expected_instructions: Some(30_646_177),
+    }
+    // The next tests (up to and including vsbx.bin) all come from http://nesdev.com/6502_cpu.txt
+    // NOTE: They are hard to debug even with the ring buffer since we don't snapshot memory
+    //       state and the test itself is self modifying code...So you'll have to use the register values
+    //       to infer state along the way.
+    dadc_test: RomTest{
+        filename: "dadc.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(21_230_741),
+        expected_instructions: Some(8_109_022),
+    }
+    dincsbc_test: RomTest{
+        filename: "dincsbc.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(18_939_481),
+        expected_instructions: Some(6_781_980),
+    }
+    dincsbc_deccmp_test: RomTest{
+        filename: "dincsbc-deccmp.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(18_095_480),
+        expected_instructions: Some(5_507_189),
+    }
+    droradc_test: RomTest{
+        filename: "droradc.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(22_148_245),
+        expected_instructions: Some(8_240_094),
+    }
+    dsbc_test: RomTest{
+        filename: "dsbc.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(18_021_977),
+        expected_instructions: Some(6_650_908),
+    }
+    dsbc_cmp_flags_test: RomTest{
+        filename: "dsbc-cmp-flags.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(14_425_356),
+        expected_instructions: Some(4_982_869),
+    }
+    sbx_test: RomTest{
+        filename: "sbx.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            if old == cpu.pc.0 {
+                println!();
+                return true
+            }
+            // On this test it JSR's to FFD2 which is the C64
+            // ROM print routine. It prints a dot for each iteration.
+            // Do the same for easier debugging if it fails.
+            if cpu.pc.0 == 0xFFD2 {
+                print!(".");
+            }
+            false
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(6_044_288_253),
+        expected_instructions: Some(2_081_694_800),
+    }
+    vsbx_test: RomTest{
+        filename: "vsbx.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xD000,
+        end_check: |old, cpu| {
+            if old == cpu.pc.0 {
+                println!();
+                return true
+            }
+            // On this test it JSR's to FFD2 which is the C64
+            // ROM print routine. It prints a dot for each iteration.
+            // Do the same for easier debugging if it fails.
+            if cpu.pc.0 == 0xFFD2 {
+                print!(".");
+            }
+            false
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xD004 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        expected_cycles: Some(7_525_173_529),
+        expected_instructions: Some(2_552_776_790),
+    }
+    bcd_test: RomTest{
+        filename: "bcd_test.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xC000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0 || old == 0xC04B
+        },
+        success_check: |_old, cpu| {
+            let val = cpu.ram.read(0x0000);
+            if val != 0x00 {
+                return Err(eyre!("Invalid value at 0x0000: Got {val:2X} and want 0x00"))
+            }
+            Ok(())
+        },
+        expected_cycles: Some(53_953_828),
+        expected_instructions: Some(17_609_916),
+    }
+    undocumented_opcodes_test: RomTest{
+        filename: "undocumented.bin",
+        cpu: Type::NMOS,
+        start_pc: 0xC000,
+        end_check: |old, cpu| {
+            old == cpu.pc.0
+        },
+        success_check: |_old, cpu| {
+            if cpu.pc.0 == 0xC123 {
+                return Ok(());
+            }
+            Err(eyre!("CPU looping at PC: 0x{:04X}", cpu.pc.0))
+        },
+        // No expected cycles/instructions because OAL can generate different paths.
+        expected_cycles: None,
+        expected_instructions: None,
+    }
+);

--- a/disassembler/src/main.rs
+++ b/disassembler/src/main.rs
@@ -136,5 +136,5 @@ fn main() -> Result<()> {
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
-    Args::command().debug_assert()
+    Args::command().debug_assert();
 }

--- a/handasm/src/main.rs
+++ b/handasm/src/main.rs
@@ -80,17 +80,13 @@ fn main() -> Result<()> {
         let mut op2 = None;
 
         // If the first field matches as an addr this must be something we can use.
-        let addr = match usize::from_str_radix(fields[0], 16) {
-            Ok(addr) => addr,
-            Err(_) => continue,
+        let Ok(addr) = usize::from_str_radix(fields[0], 16) else {
+            continue;
         };
 
         // If we have an addr opcode is required or this is a bad line and we should stop.
-        let op = match u8::from_str_radix(fields[1], 16) {
-            Ok(op) => op,
-            Err(_) => {
-                return Err(eyre!("Error parsing line {}: {}", line_num + 1, line));
-            }
+        let Ok(op) = u8::from_str_radix(fields[1], 16) else {
+            return Err(eyre!("Error parsing line {}: {}", line_num + 1, line));
         };
 
         // The next 2 are optional
@@ -128,5 +124,5 @@ where
 #[test]
 fn verify_cli() {
     use clap::CommandFactory;
-    Args::command().debug_assert()
+    Args::command().debug_assert();
 }

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -16,7 +16,7 @@ pub trait Memory {
     /// Get a copy of the whole 64k RAM block as the CPU would see it.
     /// i.e. if there is shadowing this will show that with copies in the
     /// relevant places.
-    fn ram(&self) -> [u8; MAX_SIZE];
+    fn ram<'a>(&'a self) -> &'a [u8; MAX_SIZE];
 }
 
 /// The maxmimum memory size one can address.
@@ -33,7 +33,7 @@ impl Memory for [u8; MAX_SIZE] {
 
     fn power_on(&mut self) {}
 
-    fn ram(&self) -> [u8; MAX_SIZE] {
-        *self
+    fn ram<'a>(&'a self) -> &'a [u8; MAX_SIZE] {
+        self
     }
 }

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -12,7 +12,28 @@ pub trait Memory {
     /// `power_on` will perform power on behavior such as setting specific
     /// memory locations (or randomizing).
     fn power_on(&mut self);
+
+    /// Get a copy of the whole 64k RAM block as the CPU would see it.
+    /// i.e. if there is shadowing this will show that with copies in the
+    /// relevant places.
+    fn ram(&self) -> [u8; MAX_SIZE];
 }
 
 /// The maxmimum memory size one can address.
 pub const MAX_SIZE: usize = 1 << 16;
+
+impl Memory for [u8; MAX_SIZE] {
+    fn read(&self, addr: u16) -> u8 {
+        self[usize::from(addr)]
+    }
+
+    fn write(&mut self, addr: u16, val: u8) {
+        self[usize::from(addr)] = val;
+    }
+
+    fn power_on(&mut self) {}
+
+    fn ram(&self) -> [u8; MAX_SIZE] {
+        *self
+    }
+}

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -16,7 +16,7 @@ pub trait Memory {
     /// Get a copy of the whole 64k RAM block as the CPU would see it.
     /// i.e. if there is shadowing this will show that with copies in the
     /// relevant places.
-    fn ram<'a>(&'a self) -> &'a [u8; MAX_SIZE];
+    fn ram(&self) -> &[u8; MAX_SIZE];
 }
 
 /// The maxmimum memory size one can address.
@@ -33,7 +33,7 @@ impl Memory for [u8; MAX_SIZE] {
 
     fn power_on(&mut self) {}
 
-    fn ram<'a>(&'a self) -> &'a [u8; MAX_SIZE] {
+    fn ram(&self) -> &[u8; MAX_SIZE] {
         self
     }
 }


### PR DESCRIPTION
In the CPUState case we now have to return a RC<RefCell<CPUState>> so that nothing has to be allocated/copied on each pass. String version still gets passed a rendered string so will be slow at volume.

Turns out fully copying the 64k each time is *slow* so we pre-allocate it in the circ buffer but only copy the 3 bytes at the PC value. This way disassembly can happen.

Convert String version over to new circ buf which allows removing a dep now.

Summary of perf:

No debug - 1x
Debug with new buf - 1.2x
Debug with 64k memcpy - 100x
Debug with Stringify old circ buf - 20x
Debug with Stringify new circ buf - 20x