### PR TITLE
Make labels a bit more flexible.

### DIFF
--- a/assemble/src/tests.rs
+++ b/assemble/src/tests.rs
@@ -289,7 +289,7 @@ bad_assemble_test!(
   CPUType::CMOS
   bad_bbr2: BadAssembleTest{
     asm: "cmos-bbr2.asm",
-    error: "index too large"
+    error: "Invalid zero page relative (index 10 too large - greater than 7)",
   },
   CPUType::CMOS
   bad_word: BadAssembleTest{

--- a/assemble/src/tests.rs
+++ b/assemble/src/tests.rs
@@ -217,11 +217,6 @@ bad_assemble_test!(
       error: "missing data",
   },
   CPUType::NMOS
-  bad_label: BadAssembleTest{
-      asm: "bad_label.asm",
-      error: "missing data",
-  },
-  CPUType::NMOS
   bad_label2: BadAssembleTest{
       asm: "bad_label2.asm",
       error: "Label START was never defined",
@@ -229,7 +224,7 @@ bad_assemble_test!(
   CPUType::NMOS
   bad_label3: BadAssembleTest{
       asm: "bad_label3.asm",
-      error: " only comment after parsed tokens allowed",
+      error: "invalid opcode 'some'",
   },
   CPUType::NMOS
   bad_opcode: BadAssembleTest{

--- a/testdata/badasm/bad_label3.asm
+++ b/testdata/badasm/bad_label3.asm
@@ -1,1 +1,2 @@
 START: some more tokens ; comments
+LDA #"a"

--- a/testdata/testasm.asm
+++ b/testdata/testasm.asm
@@ -21,10 +21,10 @@ LABEL EQU 0x40
 BEQ LABEL
 FOO BEQ $41
 
-LBL:
+LBL
 LBL2: ; Some comments
   JMP LBL
-LBL3 JMP LBL3
+LBL3: JMP LBL3
 LDA #"H"
 LDA #"\n"
 LDA #"\r"


### PR DESCRIPTION
The colon is optional. Single or on the same line work the same now.

Additionally for better list file debugging retain the original input line and emit that as a comment in the output. Skip for blank lines