### PR TITLE
Refactor input/cpu loop into discrete subroutines.

### DIFF
--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -117,8 +117,7 @@ jobs:
         env:
           # Disable isolation as we load external input files/images.
           # Stacked borrows because eyre doesn't work.
-          # Monitor delibertly leaks some things which is fine.
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks"
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
   #loom:
   #  runs-on: ubuntu-latest
   #  steps:

--- a/.github/workflows/safety.yml
+++ b/.github/workflows/safety.yml
@@ -117,7 +117,8 @@ jobs:
         env:
           # Disable isolation as we load external input files/images.
           # Stacked borrows because eyre doesn't work.
-          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows"
+          # Monitor delibertly leaks some things which is fine.
+          MIRIFLAGS: "-Zmiri-disable-isolation -Zmiri-disable-stacked-borrows -Zmiri-ignore-leaks"
   #loom:
   #  runs-on: ubuntu-latest
   #  steps:

--- a/c64basic/src/lib.rs
+++ b/c64basic/src/lib.rs
@@ -87,6 +87,7 @@ pub enum Keyword {
     #[strum(to_string = "INPUT#")]
     INPUTIO,
 
+    #[allow(clippy::doc_link_with_quotes)]
     /// INPUT is used to read data from the keyboard into one or more supplied variables.
     /// The INPUT command prints the optional text followed by a question mark (?) and
     /// then activates the screen editor for user input.
@@ -207,8 +208,8 @@ pub enum Keyword {
     ON,
 
     /// WAIT waits for a given memory location to match specific bit constellations.
-    /// The parameter values are specified as a bit mask, so WAITing on a value of 32
-    /// will cause the program to continue when bit 5 changes to 1. WAITing on 3 will
+    /// The parameter values are specified as a bit mask, so `WAIT`ing on a value of 32
+    /// will cause the program to continue when bit 5 changes to 1. `WAIT`ing on 3 will
     /// cause it to continue when either bit 1 or 2 is set. The optional 3rd parameter
     /// enables a check for unset bits by inverting the locations bits.
     ///
@@ -226,6 +227,7 @@ pub enum Keyword {
     /// Abbr: lO
     LOAD,
 
+    #[allow(clippy::doc_link_with_quotes)]
     /// SAVE permanently saves to a storage device such as a datasette, diskdrive
     /// or harddisk as a filetype of program (PRG). The Command SAVE can also be
     /// used in BASIC programs.
@@ -235,6 +237,7 @@ pub enum Keyword {
     /// Abbr: sA
     SAVE,
 
+    #[allow(clippy::doc_link_with_quotes)]
     /// VERIFY is used for verifying files, which were written with the
     /// BASIC-Command SAVE on a storage medium, with the data from memory (RAM).
     /// This command can used directly or in programs.
@@ -248,9 +251,9 @@ pub enum Keyword {
     /// be executed with FN afterwards. The definition may contain any legitimate
     /// mathematical expression consisting of mathematical and logical operands,
     /// functions and variables which finally results in a numeric value. Functions,
-    /// operands and system variables such as ABS(), AND, ATN(), ASC(), COS(), EXP(),
-    /// FN<function name>(), FRE(), INT(), LEN() LOG(), NOT, PEEK(), POS(), OR, RND(),
-    /// SGN(), SIN(), SQR(), STATUS (ST), TAN(), TIME (TI) or VAL() are possible.
+    /// operands and system variables such as `ABS`(), `AND`, `ATN`(), `ASC`(), `COS`(), `EXP`(),
+    /// `FN`<function name>(), `FRE`(), `INT`(), `LEN`() `LOG`(), `NOT`, `PEEK`(), `POS`(), `OR`, `RND`(),
+    /// `SGN`(), `SIN`(), `SQR`(), STATUS (`ST`), `TAN`(), TIME (`TI`) or `VAL`() are possible.
     ///
     /// DEF FN <function name>(parameter name)=<mathmatical expression>
     ///
@@ -315,6 +318,7 @@ pub enum Keyword {
     /// Abbr: cL
     CLR,
 
+    #[allow(clippy::doc_link_with_quotes)]
     /// CMD changes the data output from the screen to another peripheral device like casette,
     /// modem, printer or disk drive. CMD can be used directly or in programs. The logical
     /// filenumber is in the range 1-255 and must be selected with the BASIC command OPEN.

--- a/c64basic/src/tests.rs
+++ b/c64basic/src/tests.rs
@@ -27,6 +27,7 @@ macro_rules! list_test {
 
                         // Copy the program into place.
                         for i in 2..bytes.len() {
+                          #[allow(clippy::cast_possible_truncation)]
                             r.write(BASIC_LOAD_ADDR+(i-2) as u16, bytes[i]);
                         }
 

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -140,7 +140,7 @@ pub enum Opcode {
     /// Add with Carry A with the value at the operand address.
     ADC,
 
-    /// Undocumented opcode AHX. This stores a value as (A & X & (ADDR_HI + 1)).
+    /// Undocumented opcode AHX. This stores a value as (A & X & (`ADDR_HI` + 1)).
     AHX,
 
     /// Undocumented opcode ALR. This does AND #i and then LSR setting all associated flags
@@ -355,10 +355,10 @@ pub enum Opcode {
     /// Set the I flag.
     SEI,
 
-    /// Undocumented instruction SHX. Similar to AHX but the value stored is (X & (ADDR_HI + 1))
+    /// Undocumented instruction SHX. Similar to AHX but the value stored is (X & (`ADDR_HI` + 1))
     SHX,
 
-    /// Undocumented instruction SHX. Similar to AHX but the value stored is (Y & (ADDR_HI + 1))
+    /// Undocumented instruction SHX. Similar to AHX but the value stored is (Y & (`ADDR_HI` + 1))
     SHY,
 
     /// Undocumented instruction SLO. This does an ASL on the value at the operand address and then OR's it against A. Sets flags and carry
@@ -421,9 +421,9 @@ pub enum Opcode {
     /// Note: CMOS only on WDC implementations.
     WAI,
 
-    /// Undocumented instruction XAA. We'll go with http://visual6502.org/wiki/index.php?title=6502_Opcode_8B_(XAA,_ANE)
+    /// Undocumented instruction XAA. We'll go with <http://visual6502.org/wiki/index.php?title=6502_Opcode_8B_(XAA,_ANE)/>
     /// for implementation and pick 0xEE as the constant.
-    /// https://sourceforge.net/tracker/?func=detail&aid=2110948&group_id=223021&atid=1057617
+    /// <https://sourceforge.net/tracker/?func=detail&aid=2110948&group_id=223021&atid=1057617/>
     XAA,
 }
 
@@ -433,7 +433,7 @@ pub enum Opcode {
 pub struct Operation {
     /// op is the Opcode such as ADC, LDA, etc.
     pub op: Opcode,
-    /// AddressMode is a valid addressing mode for this opcode such as Absolute.
+    /// `AddressMode` is a valid addressing mode for this opcode such as Absolute.
     pub mode: AddressMode,
 }
 
@@ -811,16 +811,16 @@ pub struct CPUState {
     /// How many clocks have run since power on
     pub clocks: usize,
 
-    /// The current op_val
+    /// The current `op_val`
     pub op_val: u8,
 
-    /// The current op_addr
+    /// The current `op_addr`
     pub op_addr: u16,
 
     /// The dissasembly of the current instruction at PC
     pub dis: String,
 
-    /// The current op_tick
+    /// The current `op_tick`
     pub op_tick: Tick,
 }
 
@@ -837,7 +837,7 @@ impl CPUState {
         dest.clocks = self.clocks;
         dest.op_val = self.op_val;
         dest.op_addr = self.op_addr;
-        dest.dis = self.dis.clone();
+        dest.dis.clone_from(&self.dis);
         dest.op_tick = self.op_tick;
     }
 }
@@ -1282,8 +1282,6 @@ trait CPUInternal<'a>: Chip + CPU<'a> {
     // and must be implmented by the relevant struct in order to provide
     // access and mutability for the default trait methods below.
 
-    // state returns the current CPU state.
-    fn state(&self) -> State;
     // state_mut sets the current CPU state.
     fn state_mut(&mut self, new: State);
 
@@ -2837,10 +2835,6 @@ trait CPUInternal<'a>: Chip + CPU<'a> {
 
 macro_rules! cpu_internal {
     () => {
-        // state returns the current CPU state.
-        fn state(&self) -> State {
-            self.state
-        }
         // state_mut sets the current CPU state.
         fn state_mut(&mut self, new: State) {
             self.state = new;

--- a/cpu/src/lib.rs
+++ b/cpu/src/lib.rs
@@ -898,7 +898,7 @@ impl fmt::Display for CPUState {
 }
 
 /// The interface any 6502 implementation must conform to.
-pub trait CPU<'a>: Chip {
+pub trait CPU<'a>: Chip + Send {
     /// Given an `Opcode` and `AddressMode` return the valid u8 values that
     /// can represent it.
     ///
@@ -1172,6 +1172,8 @@ enum LastBusAction {
 #[cpu_base_struct]
 pub struct CPU6502<'a> {}
 
+unsafe impl Send for CPU6502<'_> {}
+
 /// The NMOS 6510 implementation for the 6502 architecture.
 /// Includes the 6 I/O pins and support for their memory mapped behavior
 /// at locations 0x0000 and 0x0001
@@ -1180,10 +1182,14 @@ pub struct CPU6510<'a> {
     io: Rc<RefCell<[io::Style; 6]>>,
 }
 
+unsafe impl Send for CPU6510<'_> {}
+
 /// The Richo implementation for the 6502 architecture.
 /// The same as an NMOS 6502 except it doesn't have BCD support for ADC/SBC."
 #[cpu_base_struct]
 pub struct CPURicoh<'a> {}
+
+unsafe impl Send for CPURicoh<'_> {}
 
 /// The CMOS implementation for the 65C02 architecture.
 /// Fixes many bugs from the 6502 (no more undocumented opcodes) and adds
@@ -1192,6 +1198,8 @@ pub struct CPURicoh<'a> {}
 #[cpu_base_struct]
 pub struct CPU65C02<'a> {}
 
+unsafe impl Send for CPU65C02<'_> {}
+
 /// The CMOS implementation for the 65C02 architecture.
 /// Fixes many bugs from the 6502 (no more undocumented opcodes) and adds
 /// additional instructions.
@@ -1199,12 +1207,16 @@ pub struct CPU65C02<'a> {}
 #[cpu_base_struct]
 pub struct CPU65C02Rockwell<'a> {}
 
+unsafe impl Send for CPU65C02Rockwell<'_> {}
+
 /// The CMOS implementation for the 65SC02 architecture.
 /// Fixes many bugs from the 6502 (no more undocumented opcodes) and adds
 /// additional instructions. This has no rockwell or WDC extensions. Those are all
 /// 1 cycle NOP in this case.
 #[cpu_base_struct]
 pub struct CPU65SC02<'a> {}
+
+unsafe impl Send for CPU65SC02<'_> {}
 
 macro_rules! common_cpu_funcs {
   ($cpu:ident, $t:expr) => {

--- a/cpu/src/tests.rs
+++ b/cpu/src/tests.rs
@@ -582,7 +582,7 @@ fn wai_test() -> Result<()> {
     step_cpu_cmos(&mut cpu)?;
     let p = cpu.pc.0;
     assert!(p == 0x2001, "PC after WAI not 0x2001 - is {p:#06X}");
-    let state = cpu.state();
+    let state = cpu.state;
     assert!(
         state == State::WaitingForInterrupt,
         "State not WAI is {state}"

--- a/cpu_proc_macros/src/lib.rs
+++ b/cpu_proc_macros/src/lib.rs
@@ -72,7 +72,7 @@ pub fn cpu_base_struct(args: TokenStream, input: TokenStream) -> TokenStream {
                   #[doc = " If set `debug` will be passed a raw `CPUState` on each instruction."]
                   #[doc = " The boolean returns indicates whether to include a full memory dump (slow)"]
                   #[doc = " or just to fill in the current PC values so dissembly can function."]
-                  debug: Option<&'a dyn Fn() -> (Rc<RefCell<CPUState>>, bool)>
+                  debug: Option<Box<dyn CPUDebug>>
                 })
                 .unwrap(),
         );

--- a/lsan-suppressions.txt
+++ b/lsan-suppressions.txt
@@ -1,4 +1,4 @@
 # These tests are intended to leak some top level objects
 # Actually was able to remove this but leave here as an example
 #leak:cpu::tests::
-leak:monitor::cpu_loop::
+#leak:monitor::cpu_loop::

--- a/lsan-suppressions.txt
+++ b/lsan-suppressions.txt
@@ -1,4 +1,4 @@
 # These tests are intended to leak some top level objects
 # Actually was able to remove this but leave here as an example
 #leak:cpu::tests::
-leak:monitor::tests::
+leak:monitor::cpu_loop::

--- a/lsan-suppressions.txt
+++ b/lsan-suppressions.txt
@@ -1,3 +1,4 @@
 # These tests are intended to leak some top level objects
 # Actually was able to remove this but leave here as an example
 #leak:cpu::tests::
+leak:monitor::tests::

--- a/monitor/src/commands.rs
+++ b/monitor/src/commands.rs
@@ -8,7 +8,7 @@ pub enum Command {
     Run(bool),
     Stop,
     Break(Location),
-    BreakList,
+    Breaklist,
     DeleteBreakpoint(usize),
     // Bool indicates whether to snapshot RAM on each instruction (expensive).
     Step(bool),
@@ -25,7 +25,7 @@ pub enum Command {
     Disassemble(Location),
     DisassembleRange(LocationRange),
     Watch(Location),
-    WatchList,
+    Watchlist,
     DeleteWatchpoint(usize),
     Load(String, Option<Location>, Option<PC>),
     Dump(String),

--- a/monitor/src/lib.rs
+++ b/monitor/src/lib.rs
@@ -1071,10 +1071,10 @@ fn process_running(
                         Ok(running)
                     }
                 }
-                _ => panic!("invalid response from run: {ret:?}"),
+                _ => Err(eyre!("Invalid return from Run: {ret:?}")),
             },
             Err(e) => {
-                outputtx.send(Output::Error(format!("Error from Run - {e}")))?;
+                outputtx.send(Output::Error(format!("Run error - {e}")))?;
                 Ok(running)
             }
         },

--- a/monitor/src/tests.rs
+++ b/monitor/src/tests.rs
@@ -104,7 +104,7 @@ fn process_running_errors_test() -> Result<()> {
 
     let want = "Invalid return from Run";
     assert!(
-        e.to_string().contains(&want),
+        e.to_string().contains(want),
         "didn't get proper error from process_running: {e:?} vs {want}"
     );
 
@@ -120,7 +120,7 @@ fn process_running_errors_test() -> Result<()> {
     match r {
         Output::Error(e) => {
             let want = "Run error - error from running";
-            assert!(e.contains(&want), "error invalid - {e} vs {want}");
+            assert!(e.contains(want), "error invalid - {e} vs {want}");
         }
         _ => panic!("Invalid output from cmd - {r:?}"),
     }
@@ -136,7 +136,7 @@ fn process_running_errors_test() -> Result<()> {
 
     let want = "Sender channel died";
     assert!(
-        e.to_string().contains(&want),
+        e.to_string().contains(want),
         "didn't get proper error from process_running: {e:?} vs {want}"
     );
 

--- a/monitor/src/tests.rs
+++ b/monitor/src/tests.rs
@@ -1601,7 +1601,7 @@ fn disassemble_tests() -> Result<()> {
 }
 
 #[test]
-#[cfg_attr(not(miri), timeout(60000))]
+#[cfg_attr(not(miri), timeout(90000))]
 #[cfg_attr(miri, timeout(900000))]
 #[allow(clippy::too_many_lines)]
 fn step_tests() -> Result<()> {

--- a/monitor_gui/src/main.rs
+++ b/monitor_gui/src/main.rs
@@ -45,7 +45,13 @@ fn main() -> Result<()> {
     let (cpucommandtx, cpucommandrx) = channel();
     // The response channel.
     let (cpucommandresptx, cpucommandresprx) = channel();
-    let c = thread::spawn(move || cpu_loop(CPUType::NMOS, &cpucommandrx, &cpucommandresptx));
+    let c = thread::spawn(move || {
+        cpu_loop(
+            Box::new(CPU6502::new(ChipDef::default())),
+            &cpucommandrx,
+            &cpucommandresptx,
+        )
+    });
     let mut cpu = Runner {
         h: c,
         n: "CPU".into(),

--- a/monitor_tui/src/main.rs
+++ b/monitor_tui/src/main.rs
@@ -57,11 +57,20 @@ fn main() -> Result<()> {
     color_eyre::install()?;
     let args: Args = Args::parse();
 
+    let cpu: Box<dyn CPU> = match args.cpu_type {
+        CPUType::NMOS => Box::new(CPU6502::new(ChipDef::default())),
+        CPUType::RICOH => Box::new(CPURicoh::new(ChipDef::default())),
+        CPUType::NMOS6510 => Box::new(CPU6510::new(ChipDef::default(), None)),
+        CPUType::CMOS => Box::new(CPU65C02::new(ChipDef::default())),
+        CPUType::CMOSRockwell => Box::new(CPU65C02Rockwell::new(ChipDef::default())),
+        CPUType::CMOS65SC02 => Box::new(CPU65SC02::new(ChipDef::default())),
+    };
+
     // The command channel.
     let (cpucommandtx, cpucommandrx) = channel();
     // The response channel.
     let (cpucommandresptx, cpucommandresprx) = channel();
-    let c = thread::spawn(move || cpu_loop(args.cpu_type, &cpucommandrx, &cpucommandresptx));
+    let c = thread::spawn(move || cpu_loop(cpu, &cpucommandrx, &cpucommandresptx));
     let mut cpu = Runner {
         h: c,
         n: "CPU",

--- a/nes/ines/src/lib.rs
+++ b/nes/ines/src/lib.rs
@@ -70,7 +70,7 @@ pub struct NES {
     /// Any trailing ROM data
     pub misc_rom: Option<Vec<u8>>,
 
-    /// The number of misc ROM's contained in the misc_rom field
+    /// The number of misc ROM's contained in the `misc_rom` field
     /// The specific cart/mapper code will need to know what to do with this.
     pub num_misc_rom: u8,
 
@@ -485,7 +485,7 @@ pub enum ExpansionDevice {
     /// Dongda PEC586 Keyboard
     DongdaPEC586Keyboard,
 
-    /// BitCorp Bit79 Keyboard
+    /// `BitCorp` Bit79 Keyboard
     BitCorpBit79Keyboard,
 
     /// Subor Keyboard
@@ -509,7 +509,7 @@ pub enum ExpansionDevice {
     /// Racer Mate Bicycle
     RacerMateBicycle,
 
-    /// UForce
+    /// `UForce`
     UForce,
 
     /// R.O.B. Stack Up


### PR DESCRIPTION
Breakdown allows actual unit tests and also can dump all the panics and just return errors.