### PR TITLE
Singlestep fixes for tests getting missed accidentally

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           # The package is checked out at the same level as the cpu package
           # so this ref is one level back.
-          SINGLE_STEP_6502_PROCESSOR_TESTS: "../SingleStepTests/65x02"
+          SINGLE_STEP_6502_PROCESSOR_TESTS: "../SingleStepTests"
   # https://twitter.com/alcuadrado/status/1571291687837732873
   update:
     runs-on: ubuntu-latest

--- a/cpu/src/tests.rs
+++ b/cpu/src/tests.rs
@@ -2194,8 +2194,17 @@ macro_rules! rom_test {
                     #[test]
                     fn $name() -> Result<()> {
                         let r = $rom_test;
-                        let res = panic::catch_unwind(|| {$rom(&r, false)});
-                        if res.is_err() {
+                        let res = panic::catch_unwind(|| { $rom(&r, false) });
+                        // So this returns either an Err (for a panic/assert) or OK() wrapping an error for
+                        // an actual error. Both of these we want a rerun in debug mode. This is done
+                        // because debug mode can have more expensive things to emit which we don't want
+                        // to bother when it's passing.
+                        let is_err = match res {
+                          Err(_) | Ok(Err(_)) => true,
+                          _ => false,
+                        };
+                        if is_err {
+                            println!("First run failed. Rerunning in debug mode\n");
                             return $rom(&r, true)
                         }
                         Ok(())
@@ -2769,8 +2778,17 @@ macro_rules! coverage_opcodes_test {
                 $(
                     #[test]
                     fn $name() -> Result<()> {
-                        let res = panic::catch_unwind(|| {$cov(false)});
-                        if res.is_err() {
+                        let res = panic::catch_unwind(|| { $cov(false) });
+                        // So this returns either an Err (for a panic/assert) or OK() wrapping an error for
+                        // an actual error. Both of these we want a rerun in debug mode. This is done
+                        // because debug mode can have more expensive things to emit which we don't want
+                        // to bother when it's passing.
+                        let is_err = match res {
+                          Err(_) | Ok(Err(_)) => true,
+                          _ => false,
+                        };
+                        if is_err {
+                            println!("First run failed. Rerunning in debug mode\n");
                             return $cov(true)
                         }
                         Ok(())
@@ -2809,9 +2827,12 @@ macro_rules! coverage_opcodes_test {
                             .join($path);
                         println!("tests base path: {}", path.display());
 
+                        // Test we see valid files.
+
                         for i in 0..=255 {
                             println!("Opening: {:?}", path.join(format!("{i:02x}.json")));
                             let mut file = File::open(path.join(format!("{i:02x}.json")))?;
+
                             let mut s = String::new();
                             file.read_to_string(&mut s)?;
                             if s.is_empty() {
@@ -2885,12 +2906,10 @@ macro_rules! coverage_opcodes_test {
                                                 // more cycles than is actually possible on a 6502
                                                 // so just insert those in if we're full. If not
                                                 // leave this as it's confusing otherwise.
-                                               // if bus.len() == 8 {
                                                     let l = bus.last().unwrap().clone();
                                                     bus.push(l.clone());
                                                     bus.push(l.clone());
                                                     bus.push(l.clone());
- //                                               }
 
                                                 // If we halted that's fine. The checks below will
                                                 // verify state. But set CPU back to running so the

--- a/cpu/src/tests.rs
+++ b/cpu/src/tests.rs
@@ -2195,6 +2195,7 @@ macro_rules! rom_test {
                     fn $name() -> Result<()> {
                         let r = $rom_test;
                         let res = panic::catch_unwind(|| { $rom(&r, false) });
+
                         // So this returns either an Err (for a panic/assert) or OK() wrapping an error for
                         // an actual error. Both of these we want a rerun in debug mode. This is done
                         // because debug mode can have more expensive things to emit which we don't want
@@ -2779,6 +2780,7 @@ macro_rules! coverage_opcodes_test {
                     #[test]
                     fn $name() -> Result<()> {
                         let res = panic::catch_unwind(|| { $cov(false) });
+
                         // So this returns either an Err (for a panic/assert) or OK() wrapping an error for
                         // an actual error. Both of these we want a rerun in debug mode. This is done
                         // because debug mode can have more expensive things to emit which we don't want


### PR DESCRIPTION
Turns out I misread catch_unwind

It returns an Err for panic (and assert then) but not regular errors. Those get wrapped in Ok()

So we need to unwrap the entire set of possibilities here to check whether to run a 2nd time for the rom/coverage tests.

Also make sure it's apparent this ran twice.